### PR TITLE
Switch Back to Main `HtmlAgilityPack`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+   // Use IntelliSense to find out which attributes exist for C# debugging
+   // Use hover for the description of the existing attributes
+   // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
+   "version": "0.2.0",
+   "configurations": [
+       {
+           "name": ".NET Core Launch (Site Simulator)",
+           "type": "coreclr",
+           "request": "launch",
+           "preLaunchTask": "build",
+           "program": "${workspaceRoot}/Abot/src/Abot.SiteSimulator/bin/Debug/netcoreapp1.0/Abot.SiteSimulator.dll",
+           "args": [],
+           "cwd": "${workspaceRoot}",
+           "stopAtEntry": false,
+           "console": "internalConsole"
+       },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickProcess}"
+        }
+    ,]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,19 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/Abot/src/Abot.SiteSimulator/Abot.SiteSimulator.csproj"
+            ],
+            "problemMatcher": "$msCompile",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/Abot/src/Abot.SiteSimulator/Abot.SiteSimulator.csproj
+++ b/Abot/src/Abot.SiteSimulator/Abot.SiteSimulator.csproj
@@ -22,13 +22,11 @@
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="0.9.9" />
-    <PackageReference Include="HtmlAgilityPack.NetCore" Version="1.5.0.1" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.8.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0.2" />
     <PackageReference Include="System.Collections.Specialized" Version="4.0.1" />
-    <PackageReference Include="System.Net.Http" Version="4.1.1" />
     <PackageReference Include="NRobotsCore" Version="1.1.2" />
     <PackageReference Include="AutoMapper" Version="5.1.1" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.1.0" />
     <PackageReference Include="System.Threading.ThreadPool" Version="4.0.10" />
     <PackageReference Include="System.Threading.Thread" Version="4.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.0.2" />

--- a/Abot/src/Abot.Tests.Integration/Abot.Tests.Integration.csproj
+++ b/Abot/src/Abot.Tests.Integration/Abot.Tests.Integration.csproj
@@ -35,20 +35,18 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170106-08" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="AutoMapper" Version="5.1.1" />
     <PackageReference Include="AngleSharp" Version="0.9.9" />
     <PackageReference Include="NLog" Version="4.4.0-betaV15" />
-    <PackageReference Include="NUnit" Version="3.4.1" />
     <PackageReference Include="Commoner" Version="1.0.12" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.4.9.5" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.8.2" />
     <PackageReference Include="NRobotsCore" Version="1.1.2" />
-    <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.1-beta-003206" />
+    <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />
-    <PackageReference Include="system.net.http.winhttphandler" Version="4.0.0" />
-    <PackageReference Include="System.Net.Primitives" Version="4.0.11" />
-    <PackageReference Include="dotnet-test-nunit" Version="3.4.0-beta-3" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="system.net.http.winhttphandler" Version="4.4.0" />
   </ItemGroup>
 
 </Project>

--- a/Abot/src/Abot.Tests.Unit/Abot.Tests.Unit.csproj
+++ b/Abot/src/Abot.Tests.Unit/Abot.Tests.Unit.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>.NET Core port of sjdirect/abot. Abot is an open source C# web crawler built for speed and flexibility. It takes care of the low level plumbing (multithreading, http requests, scheduling, link parsing, etc..). You just register for events to process the page data. You can also plugin your own implementations of core interfaces to take complete control over the crawl process.</Description>
@@ -30,8 +30,11 @@
     <None Include="App.config" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
+  <ItemGroup>
     <ProjectReference Include="..\Abot\Abot.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
@@ -42,11 +45,12 @@
     <PackageReference Include="AngleSharp" Version="0.9.9" />
     <PackageReference Include="NLog" Version="4.4.0-betaV15" />
     <PackageReference Include="NRobotsCore" Version="1.1.2" />
-    <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.500-preview2-1-003177" />
+    <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
-    <PackageReference Include="system.net.http.winhttphandler" Version="4.0.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <PackageReference Include="system.net.http.winhttphandler" Version="4.4.0" />
     <PackageReference Include="NLog.Config" Version="4.3.9" />
     <PackageReference Include="NLog.Schema" Version="4.3.9" />
     <PackageReference Include="NUnit" Version="3.8.1" />

--- a/Abot/src/Abot/Abot.csproj
+++ b/Abot/src/Abot/Abot.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="0.9.9" />
-    <PackageReference Include="HtmlAgilityPack.NetCore" Version="1.5.0.1" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.8.2" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.0.2" />
     <PackageReference Include="System.Collections.Specialized" Version="4.0.1" />
     <PackageReference Include="NRobotsCore" Version="1.1.2" />
@@ -38,12 +38,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <PackageReference Include="System.Net.Http" Version="4.1.1" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
-    <PackageReference Include="Microsoft.Net.Http" Version="2.2.22" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/Abot/src/Abot/Abot.csproj
+++ b/Abot/src/Abot/Abot.csproj
@@ -1,17 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>.NET Core port of sjdirect/abot. Abot is an open source C# web crawler built for speed and flexibility. It takes care of the low level plumbing (multithreading, http requests, scheduling, link parsing, etc..). You just register for events to process the page data. You can also plugin your own implementations of core interfaces to take complete control over the crawl process.</Description>
     <Copyright>Copyright 2012 SHARPDEV LLC</Copyright>
     <VersionPrefix>0.1.13-beta</VersionPrefix>
-    <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6.1;net46</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>AbotCore</AssemblyName>
     <PackageId>Abot</PackageId>
     <PackageTags>crawler;robot;spider</PackageTags>
     <PackageProjectUrl>https://github.com/sjdirect/abot-dotnet-core</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netstandard1.6' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
@@ -30,7 +29,7 @@
     <PackageReference Include="System.Collections.Specialized" Version="4.0.1" />
     <PackageReference Include="NRobotsCore" Version="1.1.2" />
     <PackageReference Include="AutoMapper" Version="5.1.1" />
-    <PackageReference Include="System.Reflection.TypeExtensions" Version="4.1.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.3" />
     <PackageReference Include="System.Threading.ThreadPool" Version="4.0.10" />
     <PackageReference Include="System.Threading.Thread" Version="4.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.0.2" />
@@ -41,6 +40,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Net.Http.WebRequest" />
   </ItemGroup>
 
 </Project>

--- a/Abot/src/Abot/Core/PageRequester.cs
+++ b/Abot/src/Abot/Core/PageRequester.cs
@@ -139,7 +139,7 @@ namespace Abot.Core
         //Do not mark as virtual, could cause issues in inheritance constructoring calling
         private HttpMessageHandler BuildHttpClientHandler()
         {
-#if NETSTANDARD1_6
+#if NETSTANDARD1_6_1
             var handler = new HttpClientHandler();
 #elif NET46
             var handler = new WebRequestHandler();
@@ -167,7 +167,7 @@ namespace Abot.Core
             //    handler.UseDefaultCredentials = false;
             //}
 
-#if NETSTANDARD1_6
+#if NETSTANDARD1_6_1
 
             if (!_config.IsSslCertificateValidationEnabled)
             {

--- a/Abot/src/Abot/Crawler/WebCrawler.cs
+++ b/Abot/src/Abot/Crawler/WebCrawler.cs
@@ -1001,7 +1001,7 @@ namespace Abot.Crawler
             
             string abotVersion = typeof(WebCrawler).GetTypeInfo().Assembly.GetName().Version.ToString();
             _logger.LogInformation($"{indentString}Abot Version: {abotVersion}");
-            foreach (PropertyInfo property in config.GetType().GetProperties())
+            foreach (PropertyInfo property in config.GetType().GetTypeInfo().GetProperties())
             {
                 if (property.Name != "ConfigurationExtensions")
                     _logger.LogInformation($"{indentString}{property.Name}: {property.GetValue(config, null)}");

--- a/Abot/src/Abot/Util/MemoryManager.cs
+++ b/Abot/src/Abot/Util/MemoryManager.cs
@@ -80,7 +80,7 @@ namespace Abot.Util
     }
 #endif
 
-#if NETSTANDARD1_6
+#if NETSTANDARD1_6_1
     public class CoreMemoryManager : IMemoryManager
     {
         static ILogger _logger = new LoggerFactory().CreateLogger("AbotLogger");


### PR DESCRIPTION
The original `HtmlAgilityPack` supports .NET Standard now. There
should be no need to use a fork. This PR switches back to the
main package, consolidates the versions of `HtmlAgilityPack` used
throughout the project, and upgrades everything to build against
.NET Standard 1.6.1 which is the minimum requirement for the .NET
Standard build of `HtmlAgilityPack`.

The different versions of `HtmlAgilityPack` and
`HtmlAgilityPack.Core` both have the same types in the same
namespaces. This means that projects which depend on both end up
quite a bit of trouble when it comes to actually trying to refer
to those types. It is possible to work around the conflicts but
it isn't a trivail fix. This update would make the conflicts
disappear and allow clients to use this library along with others
which depend on HtmlAgilityPack.